### PR TITLE
fix postgres env variable

### DIFF
--- a/bin/setup_aws_postgres
+++ b/bin/setup_aws_postgres
@@ -156,14 +156,14 @@ PORT=$(echo $instance | jq -r ".DBInstances[] | select(.DBInstanceIdentifier==\"
 
 
 print -nP "Creating vault roles for this database... "
-silent vault write $VAULT_PATH/roles/$readonly_role \
+silent vault write $VAULT_PATH/roles/$VAULT_POSTGRES_READONLY_ROLE \
     db_name=${DB_NAME} \
     creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
         GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";" \
     default_ttl="1h" \
     max_ttl="24h"
 
-silent vault write $VAULT_PATH/roles/$fullaccess_role \
+silent vault write $VAULT_PATH/roles/$VAULT_POSTGRES_FULLACCESS_ROLE \
     db_name=${DB_NAME} \
     creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; \
         GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO \"{{name}}\";" \
@@ -178,12 +178,15 @@ print -P "%F{yellow}username%F{$color}=%F{magenta}$MASTER_USERNAME%F{$color}"
 print -P "%F{yellow}password%F{$color}=%F{magenta}$MASTER_USER_PASSWORD%F{$color}"
 silent vault write $VAULT_PATH/config/${DB_NAME} \
     plugin_name=postgresql-database-plugin \
-    allowed_roles="$readonly_role,$fullaccess_role" \
+    allowed_roles="$VAULT_POSTGRES_READONLY_ROLE,$VAULT_POSTGRES_FULLACCESS_ROLE" \
     connection_url="$connection_url" \
     username="$MASTER_USERNAME" \
     password="$MASTER_USER_PASSWORD"
 print -P "%F{green}done.%F{$color}"
 
 print -nP "Storing postgres host into vault... "
-silent vault write $VAULT_CLUSTER_PATH/postgres host=$HOST
+silent vault write $VAULT_CLUSTER_PATH/postgres \
+    host="$HOST" \
+    username="$MASTER_USERNAME" \
+    password="$MASTER_USER_PASSWORD"
 print -P "%F{green}done.%F{$color}"


### PR DESCRIPTION
Fix the setup_aws_postgres script :

- Use the new varibale for full access and readonly roles
- save the master username and password in main vault to let the api connect to the database

Quick discussion :

I tried to setup the postgres plugin with Vault, the migration succeeded but then all the table created by the migration job was owned by the temporary vault user of the migration job and the API couldn't connect to these tables anymore, even with the `creation_statements` from vault :(. There should be a way to manage role correctly to make it work, I'll let you do that ;)